### PR TITLE
Make Version enum public, for ant-javacard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
     <groupId>com.github.martinpaljak</groupId>
     <artifactId>capfile</artifactId>
     <packaging>jar</packaging>
-    <version>18.08.16</version>
+    <version>18.08.21</version>
     <name>capfile</name>
     <url>https://github.com/martinpaljak/capfile</url>
     <description>JavaCard CAP parsing</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Elements must be without leading zero, to keep launch4j not considering it as octal -->
-        <project.version.windows>18.8.16.0</project.version.windows>
+        <project.version.windows>18.8.21.0</project.version.windows>
     </properties>
     <dependencies>
         <dependency>
@@ -60,8 +60,6 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                         <arg>-Xlint:unchecked</arg>

--- a/src/main/java/pro/javacard/CAPPackage.java
+++ b/src/main/java/pro/javacard/CAPPackage.java
@@ -56,7 +56,7 @@ public class CAPPackage {
 
     @Override
     public String toString() {
-        return (name == null ? "" : name + " ") + aid + String.format(" v%d.%d", major, minor);
+        return (name == null ? "(unknown)" : name + " ") + aid + String.format(" v%d.%d", major, minor);
     }
 
     public String getVersionString() {

--- a/src/main/java/pro/javacard/JavaCardSDK.java
+++ b/src/main/java/pro/javacard/JavaCardSDK.java
@@ -228,7 +228,7 @@ public final class JavaCardSDK {
         return jars;
     }
 
-    enum Version {
+    public enum Version {
         NONE, V21, V221, V222, V301, V304, V305;
 
         @Override


### PR DESCRIPTION
- explicitly show "(unknown)" for import AID-s that are not publicly known
- fix leading-zero version for launch4j
- increase version