### PR TITLE
Allow exp files to be located in symlinked directories

### DIFF
--- a/src/main/java/pro/javacard/OffCardVerifier.java
+++ b/src/main/java/pro/javacard/OffCardVerifier.java
@@ -75,7 +75,7 @@ public class OffCardVerifier {
             for (File e : exps) {
                 // collect all export files to a list
                 if (e.isDirectory()) {
-                    Files.walkFileTree(e.toPath(), new SimpleFileVisitor<Path>() {
+                    Files.walkFileTree(e.toPath().toRealPath(), new SimpleFileVisitor<Path>() {
                         @Override
                         public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs)
                                 throws IOException {


### PR DESCRIPTION
Files.walkFileTree() does not traverse symlinked directories unless a toRealPath() is invoked on a 'start' Path...